### PR TITLE
Fix instructions language for "rejected" entries

### DIFF
--- a/src/templates/_includes/editor-pane.html
+++ b/src/templates/_includes/editor-pane.html
@@ -116,7 +116,7 @@
 
                     <div id="history-info-{{ loop.index }}" class="workflow-history-info hidden">
                         <div class="instructions">
-                            <p>{{ submission.publisherUrl | raw }} {{ "approved this entry on {date}." | t('workflow', { date: submission.dateApproved | date('jS M Y g:ia') }) }}</p>
+                            <p>{{ submission.publisherUrl | raw }} {{ "rejected this entry on {date}." | t('workflow', { date: submission.dateRejected | date('jS M Y g:ia') }) }}</p>
 
                             {% if submission.editorNotes %}
                                 <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>


### PR DESCRIPTION
Rejected entries show "approved" word and `dateApproved` property which is incorrect, this should fix it!